### PR TITLE
Start assetWriter with video buffer

### DIFF
--- a/CameraEngine/CameraEngineVideoEncoder.swift
+++ b/CameraEngine/CameraEngineVideoEncoder.swift
@@ -156,6 +156,9 @@ class CameraEngineVideoEncoder {
     
     func appendBuffer(sampleBuffer: CMSampleBuffer!, isVideo: Bool) {
         if self.assetWriter.status == AVAssetWriterStatus.Unknown {
+            if !isVideo {
+                return
+            }
             let startTime = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
             self.assetWriter.startWriting()
             self.assetWriter.startSessionAtSourceTime(startTime)


### PR DESCRIPTION
Bug: The video frequently begins with a black screen.

Only start the assetWriter with a video sample.  Otherwise, the output video may be missing video frames at the start of the movie.  Current fix ensures that no video frames are missing.