### PR TITLE
Update CameraEngineCaptureOutput.swift

### DIFF
--- a/CameraEngine/CameraEngineCaptureOutput.swift
+++ b/CameraEngine/CameraEngineCaptureOutput.swift
@@ -41,7 +41,10 @@ class CameraEngineCaptureOutput: NSObject {
     var blockCompletionProgress: blockCompletionProgressRecording?
     
     func capturePhoto(blockCompletion: blockCompletionCapturePhoto) {
-        let connectionVideo = self.stillCameraOutput.connectionWithMediaType(AVMediaTypeVideo)
+        guard let connectionVideo  = self.stillCameraOutput.connectionWithMediaType(AVMediaTypeVideo) else {
+            blockCompletion(image: nil, error: nil)
+            return
+        }
         connectionVideo.videoOrientation = AVCaptureVideoOrientation.orientationFromUIDeviceOrientation(UIDevice.currentDevice().orientation)
         
         self.stillCameraOutput.captureStillImageAsynchronouslyFromConnection(connectionVideo) { (sampleBuffer: CMSampleBuffer!, err: NSError!) -> Void in


### PR DESCRIPTION
connectionWithMediaType may return a nil if there is no Camera (Simulator doesn't) so better to return no image, and you may return an error or nil on error.

Try to recreate the method also to support the throw error handlyng