### PR TITLE
Fixed a crashed caused by using self after deint was done.

### DIFF
--- a/CameraEngine/CameraEngine.swift
+++ b/CameraEngine/CameraEngine.swift
@@ -270,14 +270,18 @@ public class CameraEngine: NSObject {
     //MARK: Session management
     
     public func startSession() {
+        let session = self.session
+        
         dispatch_async(self.sessionQueue) { () -> Void in
-            self.session.startRunning()
+            session.startRunning()
         }
     }
     
     public func stopSession() {
+        let session = self.session
+        
         dispatch_async(self.sessionQueue) { () -> Void in
-            self.session.stopRunning()
+            session.stopRunning()
         }
     }
     


### PR DESCRIPTION
The stopSession method uses an asynchronous call, The crash occurred on the following scenario:
1. CameraEngine is used in some ViewController, hereafter called CameraViewController
2. After a while CameraViewController is dismissed, hence causing the invocation of the deinit method of CameraEngine.
3. CameraEngine's deinit calls stopSession which uses dispatch_async.
4. due to the asynchronous nature of dispatch_async, the stopSession's closure is called after CameraEngine was freed - therefore self.session.stopRunning() is causing a crash.

To fix this problem I just saved a local reference to session and used it to call stopRunning.