### PR TITLE
Fix focus and exposure state after focusing at point

### DIFF
--- a/CameraEngine/CameraEngine.swift
+++ b/CameraEngine/CameraEngine.swift
@@ -411,10 +411,18 @@ public extension CameraEngine {
                 do {
                     try currentDevice.lockForConfiguration()
                     currentDevice.focusPointOfInterest = CGPoint(x: focusPoint.x, y: focusPoint.y)
-                    currentDevice.focusMode = AVCaptureFocusMode.AutoFocus
+                    if currentDevice.focusMode == AVCaptureFocusMode.Locked {
+                        currentDevice.focusMode = AVCaptureFocusMode.AutoFocus
+                    } else {
+                        currentDevice.focusMode = AVCaptureFocusMode.ContinuousAutoFocus
+                    }
                     
                     if currentDevice.isExposureModeSupported(AVCaptureExposureMode.AutoExpose) {
-                        currentDevice.exposureMode = AVCaptureExposureMode.AutoExpose
+                        if currentDevice.exposureMode == AVCaptureExposureMode.Locked {
+                            currentDevice.exposureMode = AVCaptureExposureMode.AutoExpose
+                        } else {
+                            currentDevice.exposureMode = AVCaptureExposureMode.ContinuousAutoExposure;
+                        }
                     }
                     currentDevice.unlockForConfiguration()
                 }


### PR DESCRIPTION
The `focus:atPoint` method should not override the current focus/exposure method.

For example it results in `ContinuousAutoFocus` being changed to `AutoFocus`. `AutoFocus` changes to `Locked` automatically after it focuses, so after using the `focus atPoint` method the focus and exposure is locked resulting in poor image.
